### PR TITLE
src: impl Try for Response, change Middleware/Endpoints

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,7 +73,7 @@ jobs:
 
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        toolchain: nightly
         override: true
 
     - name: setup

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ surf = { git = "https://github.com/Fishrock123/surf", branch = "deps-http-types-
 serde = { version = "1.0.102", features = ["derive"] }
 criterion = "0.3.1"
 tempdir = "0.3.7"
+url = "2.1.1"
 
 [[test]]
 name = "nested"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,21 +32,22 @@ unstable = []
 __internal__bench = []
 
 [dependencies]
-async-h1 = { version = "2.0.1", optional = true }
+async-h1 = { git = "https://github.com/Fishrock123/async-h1", branch = "deps-http-types-response-optional-error", optional = true }
 async-sse = "3.0.0"
 async-std = { version = "1.6.0", features = ["unstable"] }
 femme = "2.0.1"
-http-types = "2.0.1"
+http-types = { git = "https://github.com/Fishrock123/http-types", branch = "response-optional-error" }
 kv-log-macro = "1.0.4"
 route-recognizer = "0.1.13"
 serde = "1.0.102"
 serde_json = "1.0.41"
 
+
 [dev-dependencies]
 async-std = { version = "1.6.0", features = ["unstable", "attributes"] }
 juniper = "0.14.1"
 portpicker = "0.1.0"
-surf = { version = "2.0.0-alpha.3", default-features = false, features = ["h1-client"] }
+surf = { git = "https://github.com/Fishrock123/surf", branch = "deps-http-types-response-optional-error", default-features = false, features = ["h1-client"] }
 serde = { version = "1.0.102", features = ["derive"] }
 criterion = "0.3.1"
 tempdir = "0.3.7"

--- a/examples/chunked.rs
+++ b/examples/chunked.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), std::io::Error> {
         app.at("/").get(|_| async move {
             let mut res = Response::new(StatusCode::Ok);
             res.set_body(Body::from_file(file!()).await.unwrap());
-            Ok(res)
+            res
         });
         app.listen("127.0.0.1:8080").await?;
         Ok(())

--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -4,20 +4,20 @@ use tide::{Request, StatusCode};
 
 /// Tide will use the the `Cookies`'s `Extract` implementation to build this parameter.
 ///
-async fn retrieve_cookie(cx: Request<()>) -> tide::Result<String> {
-    Ok(format!("hello cookies: {:?}", cx.cookie("hello").unwrap()))
+async fn retrieve_cookie(cx: Request<()>) -> tide::Response {
+    format!("hello cookies: {:?}", cx.cookie("hello").unwrap()).into()
 }
 
-async fn insert_cookie(_req: Request<()>) -> tide::Result {
+async fn insert_cookie(_req: Request<()>) -> tide::Response {
     let mut res = tide::Response::new(StatusCode::Ok);
     res.insert_cookie(Cookie::new("hello", "world"));
-    Ok(res)
+    res
 }
 
-async fn remove_cookie(_req: Request<()>) -> tide::Result {
+async fn remove_cookie(_req: Request<()>) -> tide::Response {
     let mut res = tide::Response::new(StatusCode::Ok);
     res.remove_cookie(Cookie::named("hello"));
-    Ok(res)
+    res
 }
 
 fn main() -> Result<(), std::io::Error> {

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -11,12 +11,12 @@ async fn main() -> Result<()> {
             res = res.set_status(StatusCode::ImATeapot);
             res.set_body(format!("Teapot Status: {}", msg));
         }
-        Ok(res)
+        res
     }));
 
     app.at("/").get(|_req: Request<_>| async move {
         let path = url::Url::parse("")?;
-        Ok(format!("Path is {}", path))
+        format!("Path is {}", path).into()
     });
 
     app.listen("127.0.0.1:8080").await?;

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -1,0 +1,25 @@
+use tide::{After, Request, Response, Result, StatusCode};
+
+#[async_std::main]
+async fn main() -> Result<()> {
+    tide::log::start();
+    let mut app = tide::new();
+
+    app.middleware(After(|mut res: Response| async move {
+        if let Some(err) = res.downcast_error::<url::ParseError>() {
+            let msg = err.to_string().to_owned();
+            res = res.set_status(StatusCode::ImATeapot);
+            res.set_body(format!("Teapot Status: {}", msg));
+        }
+        Ok(res)
+    }));
+
+    app.at("/").get(|_req: Request<_>| async move {
+        let path = url::Url::parse("")?;
+        Ok(format!("Path is {}", path))
+    });
+
+    app.listen("127.0.0.1:8080").await?;
+
+    Ok(())
+}

--- a/examples/fib.rs
+++ b/examples/fib.rs
@@ -9,7 +9,7 @@ fn fib(n: usize) -> usize {
     }
 }
 
-async fn fibsum(req: Request<()>) -> tide::Result<String> {
+async fn fibsum(req: Request<()>) -> tide::Response {
     use std::time::Instant;
     let n: usize = req.param("n").unwrap_or(0);
     // Start a stopwatch
@@ -23,7 +23,7 @@ async fn fibsum(req: Request<()>) -> tide::Result<String> {
         "The fib of {} is {}.\nIt was computed in {} secs.\n",
         n, fib_n, duration,
     );
-    Ok(res)
+    res.into()
 }
 // Example: HTTP GET to http://localhost:8080/fib/42
 // $ curl "http://localhost:8080/fib/42"

--- a/examples/graphql.rs
+++ b/examples/graphql.rs
@@ -72,7 +72,7 @@ fn create_schema() -> Schema {
     Schema::new(QueryRoot {}, MutationRoot {})
 }
 
-async fn handle_graphql(mut cx: Request<State>) -> tide::Result {
+async fn handle_graphql(mut cx: Request<State>) -> tide::Response {
     let query: juniper::http::GraphQLRequest = cx
         .body_json()
         .await
@@ -88,14 +88,14 @@ async fn handle_graphql(mut cx: Request<State>) -> tide::Result {
 
     let mut res = Response::new(status);
     res.set_body(Body::from_json(&response)?);
-    Ok(res)
+    res
 }
 
-async fn handle_graphiql(_: Request<State>) -> tide::Result {
+async fn handle_graphiql(_: Request<State>) -> tide::Response {
     let mut res = Response::new(StatusCode::Ok);
     res.set_body(juniper::http::graphiql::graphiql_source("/graphql"));
     res.set_content_type(tide::http::mime::HTML);
-    Ok(res)
+    res
 }
 
 fn main() -> std::io::Result<()> {

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -2,7 +2,7 @@
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
-    app.at("/").get(|_| async move { Ok("Hello, world!") });
+    app.at("/").get(|_| async move { "Hello, world!".into() });
     app.listen("127.0.0.1:8080").await?;
     Ok(())
 }

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -22,17 +22,17 @@ fn main() -> tide::Result<()> {
 
             let mut res = Response::new(200);
             res.set_body(Body::from_json(&cat)?);
-            Ok(res)
+            res
         });
 
         app.at("/animals").get(|_| async {
-            Ok(json!({
+            json!({
                 "meta": { "count": 2 },
                 "animals": [
                     { "type": "cat", "name": "chashu" },
                     { "type": "cat", "name": "nori" }
                 ]
-            }))
+            }).into()
         });
 
         app.listen("127.0.0.1:8080").await?;

--- a/examples/nested.rs
+++ b/examples/nested.rs
@@ -1,12 +1,12 @@
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
     let mut app = tide::new();
-    app.at("/").get(|_| async move { Ok("Root") });
+    app.at("/").get(|_| async move { "Root".into() });
     app.at("/api").nest({
         let mut api = tide::new();
-        api.at("/hello").get(|_| async move { Ok("Hello, world") });
+        api.at("/hello").get(|_| async move { "Hello, world".into() });
         api.at("/goodbye")
-            .get(|_| async move { Ok("Goodbye, world") });
+            .get(|_| async move { "Goodbye, world".into() });
         api
     });
     app.listen("127.0.0.1:8080").await?;

--- a/examples/redirect.rs
+++ b/examples/redirect.rs
@@ -3,19 +3,19 @@ use tide::{http::StatusCode, Redirect, Response};
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
     let mut app = tide::new();
-    app.at("/").get(|_| async move { Ok("Root") });
+    app.at("/").get(|_| async move { "Root".into() });
 
     // Redirect hackers to YouTube.
     app.at("/.env")
         .get(Redirect::new("https://www.youtube.com/watch?v=dQw4w9WgXcQ"));
 
     app.at("/users-page").get(|_| async move {
-        Ok(if signed_in() {
+        if signed_in() {
             Response::new(StatusCode::Ok)
         } else {
             // If the user is not signed in then lets redirect them to home page.
             Redirect::new("/").into()
-        })
+        }
     });
 
     app.listen("127.0.0.1:8080").await?;

--- a/examples/static_file.rs
+++ b/examples/static_file.rs
@@ -2,7 +2,7 @@
 async fn main() -> Result<(), std::io::Error> {
     tide::log::start();
     let mut app = tide::new();
-    app.at("/").get(|_| async move { Ok("visit /src/*") });
+    app.at("/").get(|_| async move { "visit /src/*".into() });
     app.at("/src").serve_dir("src/")?;
     app.listen("127.0.0.1:8080").await?;
     Ok(())

--- a/src/cookies/middleware.rs
+++ b/src/cookies/middleware.rs
@@ -49,7 +49,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for CookiesMiddleware {
                 content
             };
 
-            let mut res = next.run(ctx).await?;
+            let mut res = next.run(ctx).await;
 
             // Don't do anything if there are no cookies.
             if res.cookie_events.is_empty() {

--- a/src/fs/serve_dir.rs
+++ b/src/fs/serve_dir.rs
@@ -1,5 +1,5 @@
 use crate::log;
-use crate::{Body, Endpoint, Request, Response, Result, StatusCode};
+use crate::{Body, Endpoint, Request, Response, StatusCode};
 
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -21,7 +21,7 @@ impl<State> Endpoint<State> for ServeDir
 where
     State: Send + Sync + 'static,
 {
-    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, Result> {
+    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, Response> {
         let path = req.url().path();
         let path = path.trim_start_matches(&self.prefix);
         let path = path.trim_start_matches('/');
@@ -41,12 +41,12 @@ where
         Box::pin(async move {
             if !file_path.starts_with(&self.dir) {
                 log::warn!("Unauthorized attempt to read: {:?}", file_path);
-                return Ok(Response::new(StatusCode::Forbidden));
+                return Response::new(StatusCode::Forbidden);
             }
             let body = Body::from_file(&file_path).await?;
             let mut res = Response::new(StatusCode::Ok);
             res.set_body(body);
-            Ok(res)
+            res
         })
     }
 }

--- a/src/fs/serve_dir.rs
+++ b/src/fs/serve_dir.rs
@@ -17,7 +17,10 @@ impl ServeDir {
     }
 }
 
-impl<State> Endpoint<State> for ServeDir {
+impl<State> Endpoint<State> for ServeDir
+where
+    State: Send + Sync + 'static,
+{
     fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, Result> {
         let path = req.url().path();
         let path = path.trim_start_matches(&self.prefix);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //! # fn main() -> Result<(), std::io::Error> { block_on(async {
 //! #
 //! let mut app = tide::new();
-//! app.at("/").get(|_| async move { Ok("Hello, world!") });
+//! app.at("/").get(|_| async move { "Hello, world!".into() });
 //! app.listen("127.0.0.1:8080").await?;
 //! #
 //! # Ok(()) }) }
@@ -41,7 +41,7 @@
 //! # fn main() -> Result<(), std::io::Error> { block_on(async {
 //! #
 //! let mut app = tide::new();
-//! app.at("/").get(|req| async move { Ok(req) });
+//! app.at("/").get(|req: tide::Request<()>| async move { req.into() });
 //! app.listen("127.0.0.1:8080").await?;
 //! #
 //! # Ok(()) }) }
@@ -63,7 +63,7 @@
 //!    counter.count += 1;
 //!    let mut res = Response::new(200);
 //!    res.set_body(Body::from_json(&counter)?);
-//!    Ok(res)
+//!    res
 //! });
 //! app.listen("127.0.0.1:8080").await?;
 //! #
@@ -166,7 +166,7 @@
 //! #[async_std::main]
 //! async fn main() -> Result<(), std::io::Error> {
 //!     let mut app = tide::new();
-//!     app.at("/").get(|req: Request<()>| async move { Ok(req.bark()) });
+//!     app.at("/").get(|req: Request<()>| async move { req.bark().into() });
 //!     app.listen("127.0.0.1:8080").await
 //! }
 //! ```
@@ -184,6 +184,7 @@
 //! for Async Rust. We have a long journey ahead of us. But we're excited you're here with us!
 
 #![cfg_attr(feature = "docs", feature(doc_cfg))]
+#![feature(try_trait)]
 // #![warn(missing_docs)]
 #![warn(missing_debug_implementations, rust_2018_idioms)]
 #![doc(test(attr(deny(rust_2018_idioms, warnings))))]
@@ -233,7 +234,7 @@ pub use http_types::{self as http, Body, Error, Status, StatusCode};
 /// # fn main() -> Result<(), std::io::Error> { block_on(async {
 /// #
 /// let mut app = tide::new();
-/// app.at("/").get(|_| async move { Ok("Hello, world!") });
+/// app.at("/").get(|_| async move { "Hello, world!".into() });
 /// app.listen("127.0.0.1:8080").await?;
 /// #
 /// # Ok(()) }) }
@@ -268,7 +269,7 @@ pub fn new() -> server::Server<()> {
 /// // Initialize the application with state.
 /// let mut app = tide::with_state(state);
 /// app.at("/").get(|req: Request<State>| async move {
-///     Ok(format!("Hello, {}!", &req.state().name))
+///     format!("Hello, {}!", &req.state().name).into()
 /// });
 /// app.listen("127.0.0.1:8080").await?;
 /// #

--- a/src/log/middleware.rs
+++ b/src/log/middleware.rs
@@ -1,6 +1,6 @@
 use crate::log;
 use crate::utils::BoxFuture;
-use crate::{Middleware, Next, Request};
+use crate::{Middleware, Next, Request, Response};
 
 /// Log all incoming requests and responses.
 ///
@@ -29,7 +29,7 @@ impl LogMiddleware {
         &'a self,
         ctx: Request<State>,
         next: Next<'a, State>,
-    ) -> crate::Result {
+    ) -> Response {
         let path = ctx.url().path().to_owned();
         let method = ctx.method().to_string();
         log::info!("<-- Request received", {
@@ -62,7 +62,7 @@ impl LogMiddleware {
                 duration: format!("{:?}", start.elapsed()),
             });
         }
-        Ok(response)
+        response
     }
 }
 
@@ -71,7 +71,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for LogMiddleware {
         &'a self,
         ctx: Request<State>,
         next: Next<'a, State>,
-    ) -> BoxFuture<'a, crate::Result> {
+    ) -> BoxFuture<'a, Response> {
         Box::pin(async move { self.log(ctx, next).await })
     }
 }

--- a/src/log/middleware.rs
+++ b/src/log/middleware.rs
@@ -37,43 +37,31 @@ impl LogMiddleware {
             path: path,
         });
         let start = std::time::Instant::now();
-        match next.run(ctx).await {
-            Ok(res) => {
-                let status = res.status();
-                if status.is_server_error() {
-                    log::error!("--> Response sent", {
-                        method: method,
-                        path: path,
-                        status: status as u16,
-                        duration: format!("{:?}", start.elapsed()),
-                    });
-                } else if status.is_client_error() {
-                    log::warn!("--> Response sent", {
-                        method: method,
-                        path: path,
-                        status: status as u16,
-                        duration: format!("{:?}", start.elapsed()),
-                    });
-                } else {
-                    log::info!("--> Response sent", {
-                        method: method,
-                        path: path,
-                        status: status as u16,
-                        duration: format!("{:?}", start.elapsed()),
-                    });
-                }
-                Ok(res)
-            }
-            Err(err) => {
-                log::error!("{}", err.to_string(), {
-                    method: method,
-                    path: path,
-                    status: err.status() as u16,
-                    duration: format!("{:?}", start.elapsed()),
-                });
-                Err(err)
-            }
+        let response = next.run(ctx).await;
+        let status = response.status();
+        if status.is_server_error() {
+            log::error!("--> Response sent", {
+                method: method,
+                path: path,
+                status: status as u16,
+                duration: format!("{:?}", start.elapsed()),
+            });
+        } else if status.is_client_error() {
+            log::warn!("--> Response sent", {
+                method: method,
+                path: path,
+                status: status as u16,
+                duration: format!("{:?}", start.elapsed()),
+            });
+        } else {
+            log::info!("--> Response sent", {
+                method: method,
+                path: path,
+                status: status as u16,
+                duration: format!("{:?}", start.elapsed()),
+            });
         }
+        Ok(response)
     }
 }
 

--- a/src/log/middleware.rs
+++ b/src/log/middleware.rs
@@ -39,14 +39,15 @@ impl LogMiddleware {
         let start = std::time::Instant::now();
         let response = next.run(ctx).await;
         let status = response.status();
-        if status.is_server_error() {
-            log::error!("--> Response sent", {
+        if let Some(error) = response.error() {
+            log::error!("--> Response error", {
+                message: error.to_string(),
                 method: method,
                 path: path,
                 status: status as u16,
                 duration: format!("{:?}", start.elapsed()),
             });
-        } else if status.is_client_error() {
+        } else if status.is_client_error() || status.is_server_error() {
             log::warn!("--> Response sent", {
                 method: method,
                 path: path,

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::endpoint::DynEndpoint;
 use crate::utils::BoxFuture;
-use crate::Request;
+use crate::{Request, Response};
 
 // mod compression;
 // mod default_headers;
@@ -59,7 +59,7 @@ where
     ) -> BoxFuture<'a, crate::Result> {
         Box::pin(async move {
             let request = (self.0)(request).await;
-            next.run(request).await
+            Ok(next.run(request).await)
         })
     }
 }
@@ -89,7 +89,7 @@ pub struct After<F>(pub F);
 impl<State, F, Fut> Middleware<State> for After<F>
 where
     State: Send + Sync + 'static,
-    F: Fn(crate::Result) -> Fut + Send + Sync + 'static,
+    F: Fn(Response) -> Fut + Send + Sync + 'static,
     Fut: std::future::Future<Output = crate::Result> + Send + Sync,
 {
     fn handle<'a>(
@@ -130,12 +130,14 @@ pub struct Next<'a, State> {
 impl<'a, State: 'static> Next<'a, State> {
     /// Asynchronously execute the remaining middleware chain.
     #[must_use]
-    pub fn run(mut self, req: Request<State>) -> BoxFuture<'a, crate::Result> {
-        if let Some((current, next)) = self.next_middleware.split_first() {
-            self.next_middleware = next;
-            current.handle(req, self)
-        } else {
-            self.endpoint.call(req)
+    pub async fn run(mut self, req: Request<State>) -> BoxFuture<'a, Response> {
+        Box::pin(async move {
+            if let Some((current, next)) = self.next_middleware.split_first() {
+                self.next_middleware = next;
+                current.handle(req, self).await.into()
+            } else {
+                self.endpoint.call(req).await.into()
+            }
         }
     }
 }

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -9,7 +9,7 @@
 //! use tide::Redirect;
 //!
 //! let mut app = tide::new();
-//! app.at("/").get(|_| async move { Ok("meow") });
+//! app.at("/").get(|_| async move { "meow".into() });
 //! app.at("/nori").get(Redirect::temporary("/"));
 //! app.listen("127.0.0.1:8080").await?;
 //! #
@@ -91,9 +91,9 @@ where
     State: Send + Sync + 'static,
     T: AsRef<str> + Send + Sync + 'static,
 {
-    fn call<'a>(&'a self, _req: Request<State>) -> BoxFuture<'a, crate::Result<Response>> {
+    fn call<'a>(&'a self, _req: Request<State>) -> BoxFuture<'a, Response> {
         let res = self.into();
-        Box::pin(async move { Ok(res) })
+        Box::pin(async move { res })
     }
 }
 

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -88,6 +88,7 @@ impl<T: AsRef<str>> Redirect<T> {
 
 impl<State, T> Endpoint<State> for Redirect<T>
 where
+    State: Send + Sync + 'static,
     T: AsRef<str> + Send + Sync + 'static,
 {
     fn call<'a>(&'a self, _req: Request<State>) -> BoxFuture<'a, crate::Result<Response>> {

--- a/src/request.rs
+++ b/src/request.rs
@@ -53,7 +53,7 @@ impl<State> Request<State> {
     /// let mut app = tide::new();
     /// app.at("/").get(|req: Request<()>| async move {
     ///     assert_eq!(req.method(), http_types::Method::Get);
-    ///     Ok("")
+    ///     "".into()
     /// });
     /// app.listen("127.0.0.1:8080").await?;
     /// #
@@ -77,7 +77,7 @@ impl<State> Request<State> {
     /// let mut app = tide::new();
     /// app.at("/").get(|req: Request<()>| async move {
     ///     assert_eq!(req.url(), &"/".parse::<tide::http::Url>().unwrap());
-    ///     Ok("")
+    ///     "".into()
     /// });
     /// app.listen("127.0.0.1:8080").await?;
     /// #
@@ -101,7 +101,7 @@ impl<State> Request<State> {
     /// let mut app = tide::new();
     /// app.at("/").get(|req: Request<()>| async move {
     ///     assert_eq!(req.version(), Some(http_types::Version::Http1_1));
-    ///     Ok("")
+    ///     "".into()
     /// });
     /// app.listen("127.0.0.1:8080").await?;
     /// #
@@ -172,7 +172,7 @@ impl<State> Request<State> {
     /// let mut app = tide::new();
     /// app.at("/").get(|req: Request<()>| async move {
     ///     assert_eq!(req.header("X-Forwarded-For").unwrap(), "127.0.0.1");
-    ///     Ok("")
+    ///     "".into()
     /// });
     /// app.listen("127.0.0.1:8080").await?;
     /// #
@@ -316,7 +316,7 @@ impl<State> Request<State> {
     /// let mut app = tide::new();
     /// app.at("/").get(|mut req: Request<()>| async move {
     ///     let _body: Vec<u8> = req.body_bytes().await.unwrap();
-    ///     Ok("")
+    ///     "".into()
     /// });
     /// app.listen("127.0.0.1:8080").await?;
     /// #
@@ -350,7 +350,7 @@ impl<State> Request<State> {
     /// let mut app = tide::new();
     /// app.at("/").get(|mut req: Request<()>| async move {
     ///     let _body: String = req.body_string().await.unwrap();
-    ///     Ok("")
+    ///     "".into()
     /// });
     /// app.listen("127.0.0.1:8080").await?;
     /// #

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,6 +1,7 @@
 use std::convert::TryInto;
 use std::fmt::{Debug, Display};
 use std::ops::Index;
+use std::ops::Try;
 
 use crate::http::cookies::Cookie;
 use crate::http::headers::{self, HeaderName, HeaderValues, ToHeaderValues};
@@ -390,5 +391,22 @@ impl Index<&str> for Response {
     #[inline]
     fn index(&self, name: &str) -> &HeaderValues {
         &self.res[name]
+    }
+}
+
+impl Try for Response {
+    type Ok = Self;
+    type Error = Error;
+
+    fn into_result(self) -> crate::Result {
+        Ok(self)
+    }   
+
+    fn from_error(error: Self::Error) -> Self {
+        error.into()
+    }
+
+    fn from_ok(res: Self::Ok) -> Self {
+        res
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,5 +1,5 @@
 use std::convert::TryInto;
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 use std::ops::Index;
 
 use crate::http::cookies::Cookie;
@@ -206,6 +206,13 @@ impl Response {
     /// Returns an optional reference to the `Error` if the response was created from one, or else `None`.
     pub fn error(&self) -> Option<&Error> {
         self.res.error()
+    }
+
+    pub fn downcast_error<E>(&self) -> Option<&E>
+    where
+        E: Display + Debug + Send + Sync + 'static,
+    {
+        self.res.error()?.downcast_ref()
     }
 
     /// Takes the `Error` from the response if one exists, replacing it with `None`.

--- a/src/response.rs
+++ b/src/response.rs
@@ -204,7 +204,7 @@ impl Response {
     }
 
     /// Returns an optional reference to the `Error` if the response was created from one, or else `None`.
-    pub fn error(&mut self) -> Option<&Error> {
+    pub fn error(&self) -> Option<&Error> {
         self.res.error()
     }
 

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,7 +1,6 @@
 use std::convert::TryInto;
 use std::fmt::Debug;
 use std::ops::Index;
-use std::sync::Arc;
 
 use crate::http::cookies::Cookie;
 use crate::http::headers::{self, HeaderName, HeaderValues, ToHeaderValues};
@@ -30,16 +29,6 @@ impl Response {
         S::Error: Debug,
     {
         let res = http::Response::new(status);
-        Self {
-            res,
-            cookie_events: vec![],
-        }
-    }
-
-    /// Create a new instance from an `http_types::Error`.
-    #[must_use]
-    pub fn from_error(err: Error) -> Self {
-        let res = http::Response::from_error(err);
         Self {
             res,
             cookie_events: vec![],
@@ -220,7 +209,7 @@ impl Response {
     }
 
     /// Takes the `Error` from the response if one exists, replacing it with `None`.
-    pub fn take_error(&mut self) -> Option<Arc<Error>> {
+    pub fn take_error(&mut self) -> Option<Error> {
         self.res.take_error()
     }
 
@@ -293,7 +282,8 @@ impl From<serde_json::Value> for Response {
 
 impl From<Error> for Response {
     fn from(err: Error) -> Self {
-        Self::from_error(err)
+        let res: http::Response = err.into();
+        res.into()
     }
 }
 

--- a/src/route.rs
+++ b/src/route.rs
@@ -7,7 +7,7 @@ use crate::endpoint::MiddlewareEndpoint;
 use crate::fs::ServeDir;
 use crate::log;
 use crate::utils::BoxFuture;
-use crate::{router::Router, Endpoint, Middleware};
+use crate::{router::Router, Endpoint, Middleware, Response};
 
 /// A handle to a route.
 ///
@@ -279,7 +279,7 @@ where
     State: 'static + Send + Sync,
     E: Endpoint<State>,
 {
-    fn call<'a>(&'a self, req: crate::Request<State>) -> BoxFuture<'a, crate::Result> {
+    fn call<'a>(&'a self, req: crate::Request<State>) -> BoxFuture<'a, Response> {
         let crate::Request {
             state,
             mut req,

--- a/src/route.rs
+++ b/src/route.rs
@@ -29,7 +29,7 @@ pub struct Route<'a, State> {
     prefix: bool,
 }
 
-impl<'a, State: 'static> Route<'a, State> {
+impl<'a, State: 'static + Send + Sync> Route<'a, State> {
     pub(crate) fn new(router: &'a mut Router<State>, path: String) -> Route<'a, State> {
         Route {
             router,
@@ -274,7 +274,11 @@ impl<E> Clone for StripPrefixEndpoint<E> {
     }
 }
 
-impl<State, E: Endpoint<State>> Endpoint<State> for StripPrefixEndpoint<E> {
+impl<State, E> Endpoint<State> for StripPrefixEndpoint<E>
+where
+    State: 'static + Send + Sync,
+    E: Endpoint<State>,
+{
     fn call<'a>(&'a self, req: crate::Request<State>) -> BoxFuture<'a, crate::Result> {
         let crate::Request {
             state,

--- a/src/router.rs
+++ b/src/router.rs
@@ -84,12 +84,12 @@ impl<State: 'static + Send + Sync> Router<State> {
 
 fn not_found_endpoint<State: Send + Sync + 'static>(
     _cx: Request<State>,
-) -> BoxFuture<'static, crate::Result> {
-    Box::pin(async move { Ok(Response::new(StatusCode::NotFound)) })
+) -> BoxFuture<'static, Response> {
+    Box::pin(async move { Response::new(StatusCode::NotFound) })
 }
 
 fn method_not_allowed<State: Send + Sync + 'static>(
     _cx: Request<State>,
-) -> BoxFuture<'static, crate::Result> {
-    Box::pin(async move { Ok(Response::new(StatusCode::MethodNotAllowed)) })
+) -> BoxFuture<'static, Response> {
+    Box::pin(async move { Response::new(StatusCode::MethodNotAllowed) })
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -22,7 +22,7 @@ pub struct Selection<'a, State> {
     pub(crate) params: Params,
 }
 
-impl<State: 'static> Router<State> {
+impl<State: 'static + Send + Sync> Router<State> {
     pub fn new() -> Self {
         Router {
             method_map: HashMap::default(),
@@ -82,10 +82,14 @@ impl<State: 'static> Router<State> {
     }
 }
 
-fn not_found_endpoint<State>(_cx: Request<State>) -> BoxFuture<'static, crate::Result> {
+fn not_found_endpoint<State: Send + Sync + 'static>(
+    _cx: Request<State>,
+) -> BoxFuture<'static, crate::Result> {
     Box::pin(async move { Ok(Response::new(StatusCode::NotFound)) })
 }
 
-fn method_not_allowed<State>(_cx: Request<State>) -> BoxFuture<'static, crate::Result> {
+fn method_not_allowed<State: Send + Sync + 'static>(
+    _cx: Request<State>,
+) -> BoxFuture<'static, crate::Result> {
     Box::pin(async move { Ok(Response::new(StatusCode::MethodNotAllowed)) })
 }

--- a/src/security/cors.rs
+++ b/src/security/cors.rs
@@ -141,7 +141,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for CorsMiddleware {
 
             if origins.is_none() {
                 // This is not a CORS request if there is no Origin header
-                return next.run(req).await;
+                return Ok(next.run(req).await);
             }
 
             let origins = origins.unwrap();
@@ -156,7 +156,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for CorsMiddleware {
                 return Ok(self.build_preflight_response(&origins).into());
             }
 
-            let mut response: http_types::Response = next.run(req).await?.into();
+            let mut response: http_types::Response = next.run(req).await.into();
 
             response.insert_header(
                 headers::ACCESS_CONTROL_ALLOW_ORIGIN,

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,7 +11,7 @@ use crate::log;
 use crate::middleware::{Middleware, Next};
 use crate::router::{Router, Selection};
 use crate::utils::BoxFuture;
-use crate::{Endpoint, Request, Route};
+use crate::{Endpoint, Request, Route, Response};
 
 /// An HTTP server.
 ///
@@ -143,7 +143,7 @@ impl Server<()> {
     /// # fn main() -> Result<(), std::io::Error> { block_on(async {
     /// #
     /// let mut app = tide::new();
-    /// app.at("/").get(|_| async move { Ok("Hello, world!") });
+    /// app.at("/").get(|_| async move { "Hello, world!".into() });
     /// app.listen("127.0.0.1:8080").await?;
     /// #
     /// # Ok(()) }) }
@@ -186,7 +186,7 @@ impl<State: Send + Sync + 'static> Server<State> {
     /// // Initialize the application with state.
     /// let mut app = tide::with_state(state);
     /// app.at("/").get(|req: Request<State>| async move {
-    ///     Ok(format!("Hello, {}!", &req.state().name))
+    ///     format!("Hello, {}!", &req.state().name).into()
     /// });
     /// app.listen("127.0.0.1:8080").await?;
     /// #
@@ -213,7 +213,7 @@ impl<State: Send + Sync + 'static> Server<State> {
     ///
     /// ```rust,no_run
     /// # let mut app = tide::Server::new();
-    /// app.at("/").get(|_| async move { Ok("Hello, world!") });
+    /// app.at("/").get(|_| async move { "Hello, world!".into() });
     /// ```
     ///
     /// A path is comprised of zero or many segments, i.e. non-empty strings
@@ -369,7 +369,7 @@ impl<State: Send + Sync + 'static> Server<State> {
     /// use tide::http::{Url, Method, Request, Response};
     ///
     /// let mut app = tide::new();
-    /// app.at("/").get(|_| async move { Ok("hello world") });
+    /// app.at("/").get(|_| async move { "hello world".into() });
     ///
     /// let req = Request::new(Method::Get, Url::parse("https://example.com")?);
     /// let res: Response = app.respond(req).await?;
@@ -432,7 +432,7 @@ impl<State> Clone for Server<State> {
 impl<State: Sync + Send + 'static, InnerState: Sync + Send + 'static> Endpoint<State>
     for Server<InnerState>
 {
-    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, crate::Result> {
+    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, Response> {
         let Request {
             req,
             mut route_params,
@@ -454,7 +454,7 @@ impl<State: Sync + Send + 'static, InnerState: Sync + Send + 'static> Endpoint<S
                 next_middleware: &middleware,
             };
 
-            Ok(next.run(req).await)
+            next.run(req).await
         })
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -399,26 +399,23 @@ impl<State: Send + Sync + 'static> Server<State> {
             next_middleware: &middleware,
         };
 
-        match next.run(req).await {
-            Ok(value) => {
-                let res: http_types::Response = value.into();
-                // We assume that if an error was manually cast to a
-                // Response that we actually want to send the body to the
-                // client. At this point we don't scrub the message.
-                Ok(res.into())
-            }
-            Err(err) => {
-                let mut res = http_types::Response::new(err.status());
-                res.set_content_type(http_types::mime::PLAIN);
-                // Only send the message if it is a non-500 range error. All
-                // errors default to 500 by default, so sending the error
-                // body is opt-in at the call site.
-                if !res.status().is_server_error() {
-                    res.set_body(err.to_string());
-                }
-                Ok(res.into())
+        let res = next.run(req).await;
+        let mut res: http_types::Response = res.into();
+
+        if res.len().is_some() {
+            return Ok(res.into());
+        }
+
+        if let Some(err) = res.error() {
+            // Only send the message if it is a non-500 range error. All
+            // errors default to 500 by default, so sending the error
+            // body is opt-in at the call site.
+            if !err.status().is_server_error() {
+                let msg = err.to_string();
+                res.set_body(msg);
             }
         }
+        Ok(res.into())
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -454,8 +454,7 @@ impl<State: Sync + Send + 'static, InnerState: Sync + Send + 'static> Endpoint<S
                 next_middleware: &middleware,
             };
 
-            let res = next.run(req).await?;
-            Ok(res)
+            Ok(next.run(req).await)
         })
     }
 }

--- a/src/sse/endpoint.rs
+++ b/src/sse/endpoint.rs
@@ -44,7 +44,7 @@ where
     F: Fn(Request<State>, Sender) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<()>> + Send + Sync + 'static,
 {
-    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, Result<Response>> {
+    fn call<'a>(&'a self, req: Request<State>) -> BoxFuture<'a, Response> {
         let handler = self.handler.clone();
         Box::pin(async move {
             let (sender, encoder) = async_sse::encode();
@@ -64,7 +64,7 @@ where
             let body = Body::from_reader(BufReader::new(encoder), None);
             res.set_body(body);
 
-            Ok(res)
+            res
         })
     }
 }

--- a/tests/chunked-encode-large.rs
+++ b/tests/chunked-encode-large.rs
@@ -77,7 +77,7 @@ async fn chunked_large() -> Result<(), http_types::Error> {
             let body = Cursor::new(TEXT.to_owned());
             res.set_body(Body::from_reader(body, None));
             res.set_content_type(mime::PLAIN);
-            Ok(res)
+            res
         });
         app.listen(("localhost", port)).await?;
         Result::<(), http_types::Error>::Ok(())

--- a/tests/chunked-encode-small.rs
+++ b/tests/chunked-encode-small.rs
@@ -26,7 +26,7 @@ async fn chunked_large() -> Result<(), http_types::Error> {
             let body = Cursor::new(TEXT.to_owned());
             res.set_body(Body::from_reader(body, None));
             res.set_content_type(mime::PLAIN);
-            Ok(res)
+            res
         });
         app.listen(("localhost", port)).await?;
         Result::<(), http_types::Error>::Ok(())

--- a/tests/cookies.rs
+++ b/tests/cookies.rs
@@ -6,31 +6,31 @@ use tide::{Request, Response, Server, StatusCode};
 
 static COOKIE_NAME: &str = "testCookie";
 
-async fn retrieve_cookie(cx: Request<()>) -> tide::Result<String> {
-    Ok(format!(
+async fn retrieve_cookie(cx: Request<()>) -> tide::Response {
+    format!(
         "{} and also {}",
         cx.cookie(COOKIE_NAME).unwrap().value(),
         cx.cookie("secondTestCookie").unwrap().value()
-    ))
+    ).into()
 }
 
-async fn insert_cookie(_req: Request<()>) -> tide::Result {
+async fn insert_cookie(_req: Request<()>) -> tide::Response {
     let mut res = Response::new(StatusCode::Ok);
     res.insert_cookie(Cookie::new(COOKIE_NAME, "NewCookieValue"));
-    Ok(res)
+    res
 }
 
-async fn remove_cookie(_req: Request<()>) -> tide::Result {
+async fn remove_cookie(_req: Request<()>) -> tide::Response {
     let mut res = Response::new(StatusCode::Ok);
     res.remove_cookie(Cookie::named(COOKIE_NAME));
-    Ok(res)
+    res
 }
 
-async fn set_multiple_cookie(_req: Request<()>) -> tide::Result {
+async fn set_multiple_cookie(_req: Request<()>) -> tide::Response {
     let mut res = Response::new(StatusCode::Ok);
     res.insert_cookie(Cookie::new("C1", "V1"));
     res.insert_cookie(Cookie::new("C2", "V2"));
-    Ok(res)
+    res
 }
 
 fn app() -> crate::Server<()> {

--- a/tests/nested.rs
+++ b/tests/nested.rs
@@ -51,7 +51,7 @@ async fn nested_middleware() {
             next: Next<'a, State>,
         ) -> BoxFuture<'a, tide::Result<tide::Response>> {
             Box::pin(async move {
-                let mut res = next.run(req).await?;
+                let mut res = next.run(req).await;
                 res.insert_header("X-Tide-Test", "1");
                 Ok(res)
             })

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -49,7 +49,7 @@ async fn json_content_type() {
         map.insert(None, 6);
         let mut resp = Response::new(StatusCode::Ok);
         resp.set_body(Body::from_json(&map)?);
-        Ok(resp)
+        resp
     });
     let req = http::Request::new(
         Method::Get,

--- a/tests/route_middleware.rs
+++ b/tests/route_middleware.rs
@@ -21,17 +21,17 @@ impl<State: Send + Sync + 'static> Middleware<State> for TestMiddleware {
         &'a self,
         req: tide::Request<State>,
         next: tide::Next<'a, State>,
-    ) -> BoxFuture<'a, tide::Result<tide::Response>> {
+    ) -> BoxFuture<'a, tide::Response> {
         Box::pin(async move {
             let mut res = next.run(req).await;
             res.insert_header(self.0.clone(), self.1);
-            Ok(res)
+            res
         })
     }
 }
 
-async fn echo_path<State>(req: tide::Request<State>) -> tide::Result<String> {
-    Ok(req.url().path().to_string())
+async fn echo_path<State>(req: tide::Request<State>) -> tide::Response {
+    req.url().path().to_string().into()
 }
 
 #[async_std::test]

--- a/tests/route_middleware.rs
+++ b/tests/route_middleware.rs
@@ -23,7 +23,7 @@ impl<State: Send + Sync + 'static> Middleware<State> for TestMiddleware {
         next: tide::Next<'a, State>,
     ) -> BoxFuture<'a, tide::Result<tide::Response>> {
         Box::pin(async move {
-            let mut res = next.run(req).await?;
+            let mut res = next.run(req).await;
             res.insert_header(self.0.clone(), self.1);
             Ok(res)
         })

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -18,7 +18,7 @@ fn hello_world() -> Result<(), http_types::Error> {
                 assert!(req.peer_addr().is_some());
                 let mut res = Response::new(StatusCode::Ok);
                 res.set_body("says hello");
-                Ok(res)
+                res
             });
             app.listen(("localhost", port)).await?;
             Result::<(), http_types::Error>::Ok(())
@@ -45,7 +45,7 @@ fn echo_server() -> Result<(), http_types::Error> {
         let port = test_utils::find_port().await;
         let server = task::spawn(async move {
             let mut app = tide::new();
-            app.at("/").get(|req| async move { Ok(req) });
+            app.at("/").get(|req: Request<()>| async move { req.into() });
 
             app.listen(("localhost", port)).await?;
             Result::<(), http_types::Error>::Ok(())
@@ -83,7 +83,7 @@ fn json() -> Result<(), http_types::Error> {
                 counter.count = 1;
                 let mut res = Response::new(StatusCode::Ok);
                 res.set_body(Body::from_json(&counter)?);
-                Ok(res)
+                res
             });
             app.listen(("localhost", port)).await?;
             Result::<(), http_types::Error>::Ok(())

--- a/tests/wildcard.rs
+++ b/tests/wildcard.rs
@@ -1,34 +1,34 @@
 use http_types::{Method, StatusCode, Url};
-use tide::{http, Request};
+use tide::{http, Request, Response};
 
-async fn add_one(cx: Request<()>) -> Result<String, tide::Error> {
+async fn add_one(cx: Request<()>) -> Response {
     match cx.param::<i64>("num") {
-        Ok(num) => Ok((num + 1).to_string()),
-        Err(err) => Err(tide::Error::new(StatusCode::BadRequest, err)),
+        Ok(num) => (num + 1).to_string().into(),
+        Err(err) => Err(tide::Error::new(StatusCode::BadRequest, err))?,
     }
 }
 
-async fn add_two(cx: Request<()>) -> Result<String, tide::Error> {
+async fn add_two(cx: Request<()>) -> Response {
     let one = cx
         .param::<i64>("one")
         .map_err(|err| tide::Error::new(StatusCode::BadRequest, err))?;
     let two = cx
         .param::<i64>("two")
         .map_err(|err| tide::Error::new(StatusCode::BadRequest, err))?;
-    Ok((one + two).to_string())
+    (one + two).to_string().into()
 }
 
-async fn echo_path(cx: Request<()>) -> Result<String, tide::Error> {
+async fn echo_path(cx: Request<()>) -> Response {
     match cx.param::<String>("path") {
-        Ok(path) => Ok(path),
-        Err(err) => Err(tide::Error::new(StatusCode::BadRequest, err)),
+        Ok(path) => path.into(),
+        Err(err) => Err(tide::Error::new(StatusCode::BadRequest, err))?,
     }
 }
 
-async fn echo_empty(cx: Request<()>) -> Result<String, tide::Error> {
+async fn echo_empty(cx: Request<()>) -> Response {
     match cx.param::<String>("") {
-        Ok(path) => Ok(path),
-        Err(err) => Err(tide::Error::new(StatusCode::BadRequest, err)),
+        Ok(path) => path.into(),
+        Err(err) => Err(tide::Error::new(StatusCode::BadRequest, err))?,
     }
 }
 
@@ -174,7 +174,7 @@ async fn invalid_wildcard() {
 #[async_std::test]
 async fn nameless_wildcard() {
     let mut app = tide::Server::new();
-    app.at("/echo/:").get(|_| async move { Ok("") });
+    app.at("/echo/:").get(|_| async move { "".into() });
 
     let req = http::Request::new(
         Method::Get,


### PR DESCRIPTION
Requires `#![feature(try_trait)]` and will only compile on rust nightly!

Moves away from `Ok(res)` and `Ok(impl Into<Response>` in favor of returning `Response` directly, with error propogation via `?` handled by the `Try` trait.